### PR TITLE
Add optional player data saving configuration

### DIFF
--- a/src/main/java/me/wyzebb/playerviewdistancecontroller/PlayerViewDistanceController.java
+++ b/src/main/java/me/wyzebb/playerviewdistancecontroller/PlayerViewDistanceController.java
@@ -233,6 +233,10 @@ public final class PlayerViewDistanceController extends JavaPlugin {
         }
     }
 
+    public static boolean isPlayerDataSavingEnabled() {
+        return plugin.getConfig().getBoolean("save-player-data", true);
+    }
+
     @Override
     public void onDisable() {
         playerAfkMap.clear();

--- a/src/main/java/me/wyzebb/playerviewdistancecontroller/commands/subcommands/SetCommand.java
+++ b/src/main/java/me/wyzebb/playerviewdistancecontroller/commands/subcommands/SetCommand.java
@@ -1,5 +1,6 @@
 package me.wyzebb.playerviewdistancecontroller.commands.subcommands;
 
+import me.wyzebb.playerviewdistancecontroller.PlayerViewDistanceController;
 import me.wyzebb.playerviewdistancecontroller.data.PlayerDataHandler;
 import me.wyzebb.playerviewdistancecontroller.utility.ClampAmountUtility;
 import me.wyzebb.playerviewdistancecontroller.utility.DataProcessorUtility;
@@ -132,18 +133,22 @@ public class SetCommand extends SubCommand {
                 // Remove the data handler from memory and save
                 PlayerDataHandler dataHandler = DataHandlerHandler.getPlayerDataHandler(target);
 
-                File playerDataFile = DataHandlerHandler.getPlayerDataFile(target);
-                FileConfiguration cfg = YamlConfiguration.loadConfiguration(playerDataFile);
+                if (PlayerViewDistanceController.isPlayerDataSavingEnabled()) {
+                    File playerDataFile = DataHandlerHandler.getPlayerDataFile(target);
+                    FileConfiguration cfg = YamlConfiguration.loadConfiguration(playerDataFile);
 
-                cfg.set("chunks", dataHandler.getChunks());
-                cfg.set("chunksOthers", dataHandler.getChunksOthers());
-                cfg.set("pingMode", dataHandler.isPingMode());
+                    cfg.set("chunks", dataHandler.getChunks());
+                    cfg.set("chunksOthers", dataHandler.getChunksOthers());
+                    cfg.set("pingMode", dataHandler.isPingMode());
 
-                try {
-                    cfg.save(playerDataFile);
-                } catch (Exception ex) {
-                    plugin.getLogger().severe("An exception occurred when setting view distance data for " + target.getName() + ": " + ex.getMessage());
-                } finally {
+                    try {
+                        cfg.save(playerDataFile);
+                    } catch (Exception ex) {
+                        plugin.getLogger().severe("An exception occurred when setting view distance data for " + target.getName() + ": " + ex.getMessage());
+                    } finally {
+                        DataHandlerHandler.setPlayerDataHandler(target, null);
+                    }
+                } else {
                     DataHandlerHandler.setPlayerDataHandler(target, null);
                 }
             }

--- a/src/main/java/me/wyzebb/playerviewdistancecontroller/data/VdCalculator.java
+++ b/src/main/java/me/wyzebb/playerviewdistancecontroller/data/VdCalculator.java
@@ -29,7 +29,7 @@ public class VdCalculator {
         // Get an instance of the player data handler for the specific player
         File playerDataFile = DataHandlerHandler.getPlayerDataFile(player);
 
-        if (playerDataFile.exists() && !luckPermsEvent) {
+        if (playerDataFile.exists() && !luckPermsEvent && PlayerViewDistanceController.isPlayerDataSavingEnabled()) {
             FileConfiguration cfg = YamlConfiguration.loadConfiguration(playerDataFile);
             amount = ClampAmountUtility.clampChunkValue(cfg.getInt("chunks"));
             amountOthers = cfg.getInt("chunksOthers");
@@ -136,7 +136,7 @@ public class VdCalculator {
             dataHandler.setPingMode(false);
 
             DataHandlerHandler.setPlayerDataHandler(player, dataHandler);
-        } else {
+        } else if (PlayerViewDistanceController.isPlayerDataSavingEnabled()) {
             cfg.set("chunks", 32);
             cfg.set("chunksOthers", 0);
             cfg.set("pingMode", false);
@@ -167,7 +167,7 @@ public class VdCalculator {
 
             PlayerDataHandler dataHandler = DataHandlerHandler.getPlayerDataHandler(player);
 
-            if (playerDataFile.exists()) {
+            if (playerDataFile.exists() && PlayerViewDistanceController.isPlayerDataSavingEnabled()) {
                 FileConfiguration cfg = YamlConfiguration.loadConfiguration(playerDataFile);
 
                 dataHandler.setChunks(ClampAmountUtility.clampChunkValue(cfg.getInt("chunks")));

--- a/src/main/java/me/wyzebb/playerviewdistancecontroller/listeners/UpdateVDListeners.java
+++ b/src/main/java/me/wyzebb/playerviewdistancecontroller/listeners/UpdateVDListeners.java
@@ -77,18 +77,23 @@ public class UpdateVDListeners implements Listener {
     private void onPlayerQuit(PlayerQuitEvent e) {
         PlayerDataHandler dataHandler = DataHandlerHandler.getPlayerDataHandler(e.getPlayer());
 
-        File playerDataFile = DataHandlerHandler.getPlayerDataFile(e.getPlayer());
-        FileConfiguration cfg = YamlConfiguration.loadConfiguration(playerDataFile);
+        if (PlayerViewDistanceController.isPlayerDataSavingEnabled()) {
+            File playerDataFile = DataHandlerHandler.getPlayerDataFile(e.getPlayer());
+            FileConfiguration cfg = YamlConfiguration.loadConfiguration(playerDataFile);
 
-        cfg.set("chunks", dataHandler.getChunks());
-        cfg.set("chunksOthers", dataHandler.getChunksOthers());
-        cfg.set("pingMode", dataHandler.isPingMode());
+            cfg.set("chunks", dataHandler.getChunks());
+            cfg.set("chunksOthers", dataHandler.getChunksOthers());
+            cfg.set("pingMode", dataHandler.isPingMode());
 
-        try {
-            cfg.save(playerDataFile);
-        } catch (Exception ex) {
-            plugin.getLogger().severe("An exception occurred when setting view distance data for " + e.getPlayer().getName() + ": " + ex.getMessage());
-        } finally {
+            try {
+                cfg.save(playerDataFile);
+            } catch (Exception ex) {
+                plugin.getLogger().severe("An exception occurred when setting view distance data for " + e.getPlayer().getName() + ": " + ex.getMessage());
+            } finally {
+                PlayerViewDistanceController.playerAfkMap.remove(e.getPlayer().getUniqueId());
+                DataHandlerHandler.setPlayerDataHandler(e.getPlayer(), null);
+            }
+        } else {
             PlayerViewDistanceController.playerAfkMap.remove(e.getPlayer().getUniqueId());
             DataHandlerHandler.setPlayerDataHandler(e.getPlayer(), null);
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -18,6 +18,10 @@ max-distance: 32
 # Minimum view distance for anyone (Cannot be less than 2)
 min-distance: 2
 
+# Whether to save player view distance preferences to disk (defaults to true)
+# When disabled, players start fresh each session with default/LuckPerms settings
+save-player-data: true
+
 # Display a message when a player joins telling them what their view distance is set to
 # This message only sends if afkOnJoin is false
 display-msg-on-join: true


### PR DESCRIPTION
Adds save-player-data config option to control whether player view distance preferences persist between sessions. When disabled, players start with default/LuckPerms settings each time they join.