### PR TITLE
feat: simulation distance syncing based on view distance (#27)

### DIFF
--- a/src/main/java/me/wyzebb/playerviewdistancecontroller/PlayerViewDistanceController.java
+++ b/src/main/java/me/wyzebb/playerviewdistancecontroller/PlayerViewDistanceController.java
@@ -222,8 +222,8 @@ public final class PlayerViewDistanceController extends JavaPlugin {
 
                 player.setViewDistance(afkChunks);
 
-                if (plugin.getConfig().getBoolean("sync-simulation-distance")) {
-                    player.setSimulationDistance(afkChunks);
+                if (SimulationDistanceUtility.isSimulationSyncEnabled()) {
+                    player.setSimulationDistance(SimulationDistanceUtility.calculateSimulationDistance(afkChunks));
                 }
 
                 playerAfkMap.put(playerId, 0);

--- a/src/main/java/me/wyzebb/playerviewdistancecontroller/commands/subcommands/SetCommand.java
+++ b/src/main/java/me/wyzebb/playerviewdistancecontroller/commands/subcommands/SetCommand.java
@@ -4,6 +4,7 @@ import me.wyzebb.playerviewdistancecontroller.PlayerViewDistanceController;
 import me.wyzebb.playerviewdistancecontroller.data.PlayerDataHandler;
 import me.wyzebb.playerviewdistancecontroller.utility.ClampAmountUtility;
 import me.wyzebb.playerviewdistancecontroller.utility.DataProcessorUtility;
+import me.wyzebb.playerviewdistancecontroller.utility.SimulationDistanceUtility;
 import me.wyzebb.playerviewdistancecontroller.integrations.LPDetector;
 import me.wyzebb.playerviewdistancecontroller.utility.DataHandlerHandler;
 import me.wyzebb.playerviewdistancecontroller.lang.LanguageManager;
@@ -124,8 +125,8 @@ public class SetCommand extends SubCommand {
             if (target.isOnline()) {
                 ((Player) target).setViewDistance(amount);
 
-                if (plugin.getConfig().getBoolean("sync-simulation-distance")) {
-                    ((Player) target).setSimulationDistance(amount);
+                if (SimulationDistanceUtility.isSimulationSyncEnabled()) {
+                    ((Player) target).setSimulationDistance(SimulationDistanceUtility.calculateSimulationDistance(amount));
                 }
 
                 MessageProcessor.processMessage("messages.target-view-distance-change", 2, target, amount, (Player) target);

--- a/src/main/java/me/wyzebb/playerviewdistancecontroller/commands/subcommands/SetOnlineCommand.java
+++ b/src/main/java/me/wyzebb/playerviewdistancecontroller/commands/subcommands/SetOnlineCommand.java
@@ -2,6 +2,7 @@ package me.wyzebb.playerviewdistancecontroller.commands.subcommands;
 
 import me.wyzebb.playerviewdistancecontroller.utility.ClampAmountUtility;
 import me.wyzebb.playerviewdistancecontroller.utility.DataProcessorUtility;
+import me.wyzebb.playerviewdistancecontroller.utility.SimulationDistanceUtility;
 import me.wyzebb.playerviewdistancecontroller.lang.LanguageManager;
 import me.wyzebb.playerviewdistancecontroller.lang.MessageProcessor;
 import org.bukkit.command.CommandSender;
@@ -57,8 +58,8 @@ public class SetOnlineCommand extends SubCommand {
                         DataProcessorUtility.processDataOthers(p, amount);
                         p.setViewDistance(amount);
 
-                        if (plugin.getConfig().getBoolean("sync-simulation-distance")) {
-                            p.setSimulationDistance(amount);
+                        if (SimulationDistanceUtility.isSimulationSyncEnabled()) {
+                            p.setSimulationDistance(SimulationDistanceUtility.calculateSimulationDistance(amount));
                         }
                     }
                 } catch (Exception e) {

--- a/src/main/java/me/wyzebb/playerviewdistancecontroller/data/VdCalculator.java
+++ b/src/main/java/me/wyzebb/playerviewdistancecontroller/data/VdCalculator.java
@@ -81,8 +81,8 @@ public class VdCalculator {
 
         boolean msgSent = false;
 
-        if (plugin.getConfig().getBoolean("sync-simulation-distance")) {
-            player.setSimulationDistance(amount);
+        if (SimulationDistanceUtility.isSimulationSyncEnabled()) {
+            player.setSimulationDistance(SimulationDistanceUtility.calculateSimulationDistance(finalChunks));
         }
 
         if (worldChange && finalChunks != luckpermsDistance) {

--- a/src/main/java/me/wyzebb/playerviewdistancecontroller/listeners/UpdateVDListeners.java
+++ b/src/main/java/me/wyzebb/playerviewdistancecontroller/listeners/UpdateVDListeners.java
@@ -7,6 +7,7 @@ import me.wyzebb.playerviewdistancecontroller.data.VdCalculator;
 import me.wyzebb.playerviewdistancecontroller.data.PlayerDataHandler;
 import me.wyzebb.playerviewdistancecontroller.utility.ClampAmountUtility;
 import me.wyzebb.playerviewdistancecontroller.utility.DataHandlerHandler;
+import me.wyzebb.playerviewdistancecontroller.utility.SimulationDistanceUtility;
 import me.wyzebb.playerviewdistancecontroller.lang.MessageProcessor;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
@@ -63,8 +64,8 @@ public class UpdateVDListeners implements Listener {
                 if (!player.hasPermission("pvdc.bypass-afk")) {
                     player.setViewDistance(afkChunks);
 
-                    if (plugin.getConfig().getBoolean("sync-simulation-distance")) {
-                        player.setSimulationDistance(afkChunks);
+                    if (SimulationDistanceUtility.isSimulationSyncEnabled()) {
+                        player.setSimulationDistance(SimulationDistanceUtility.calculateSimulationDistance(afkChunks));
                     }
 
                     PlayerViewDistanceController.playerAfkMap.put(player.getUniqueId(), 0);

--- a/src/main/java/me/wyzebb/playerviewdistancecontroller/utility/DataProcessorUtility.java
+++ b/src/main/java/me/wyzebb/playerviewdistancecontroller/utility/DataProcessorUtility.java
@@ -6,8 +6,6 @@ import me.wyzebb.playerviewdistancecontroller.lang.MessageProcessor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
-import static me.wyzebb.playerviewdistancecontroller.PlayerViewDistanceController.plugin;
-
 public class DataProcessorUtility {
     public static void processData(OfflinePlayer target, int amount) {
         PlayerDataHandler dataHandler = DataHandlerHandler.getPlayerDataHandler(target);
@@ -16,8 +14,8 @@ public class DataProcessorUtility {
         if (target.isOnline()) {
             ((Player) target).setViewDistance(amount);
 
-            if (plugin.getConfig().getBoolean("sync-simulation-distance")) {
-                ((Player) target).setSimulationDistance(amount);
+            if (SimulationDistanceUtility.isSimulationSyncEnabled()) {
+                ((Player) target).setSimulationDistance(SimulationDistanceUtility.calculateSimulationDistance(amount));
             }
         }
     }
@@ -42,8 +40,8 @@ public class DataProcessorUtility {
         target.setViewDistance(pingChunks);
         MessageProcessor.processMessage("messages.ping-optimised", 2, pingChunks, target);
 
-        if (plugin.getConfig().getBoolean("sync-simulation-distance")) {
-            target.setSimulationDistance(pingChunks);
+        if (SimulationDistanceUtility.isSimulationSyncEnabled()) {
+            target.setSimulationDistance(SimulationDistanceUtility.calculateSimulationDistance(pingChunks));
         }
     }
 }

--- a/src/main/java/me/wyzebb/playerviewdistancecontroller/utility/DynamicModeHandler.java
+++ b/src/main/java/me/wyzebb/playerviewdistancecontroller/utility/DynamicModeHandler.java
@@ -37,8 +37,8 @@ public class DynamicModeHandler {
 
                     player.setViewDistance(optimisedChunks);
 
-                    if (plugin.getConfig().getBoolean("sync-simulation-distance")) {
-                        player.setSimulationDistance(optimisedChunks);
+                    if (SimulationDistanceUtility.isSimulationSyncEnabled()) {
+                        player.setSimulationDistance(SimulationDistanceUtility.calculateSimulationDistance(optimisedChunks));
                     }
 
                     if (optimisedChunks != maxAllowed && plugin.getConfig().getBoolean("send-dynamic-msgs")) {

--- a/src/main/java/me/wyzebb/playerviewdistancecontroller/utility/SimulationDistanceUtility.java
+++ b/src/main/java/me/wyzebb/playerviewdistancecontroller/utility/SimulationDistanceUtility.java
@@ -1,0 +1,51 @@
+package me.wyzebb.playerviewdistancecontroller.utility;
+
+import static me.wyzebb.playerviewdistancecontroller.PlayerViewDistanceController.plugin;
+
+public class SimulationDistanceUtility {
+
+    private static final int MAX_POSSIBLE = 32;
+    private static final int MIN_POSSIBLE = 2;
+
+    /**
+     * Calculate simulation distance based on view distance and sync percentage
+     * @param viewDistance The current view distance
+     * @return The calculated simulation distance
+     */
+    public static int calculateSimulationDistance(int viewDistance) {
+        int syncPercent = plugin.getConfig().getInt("sync-simulation-distance-percent", 60);
+
+        // If sync is disabled (0%), use default simulation distance settings
+        if (syncPercent <= 0) {
+            return clampSimulationDistance(plugin.getConfig().getInt("default-simulation-distance", 10));
+        }
+
+        // Calculate simulation distance as percentage of view distance
+        int simulationDistance = (int) Math.ceil((viewDistance * syncPercent) / 100.0);
+
+        return clampSimulationDistance(simulationDistance);
+    }
+
+    /**
+     * Clamp simulation distance to configured min/max values
+     * @param amount The simulation distance to clamp
+     * @return The clamped simulation distance
+     */
+    public static int clampSimulationDistance(int amount) {
+        amount = Math.min(MAX_POSSIBLE, amount);
+        amount = Math.max(MIN_POSSIBLE, amount);
+
+        amount = Math.min(plugin.getConfig().getInt("max-simulation-distance", 32), amount);
+        amount = Math.max(plugin.getConfig().getInt("min-simulation-distance", 2), amount);
+
+        return amount;
+    }
+
+    /**
+     * Check if simulation distance syncing is enabled
+     * @return true if sync percentage is greater than 0
+     */
+    public static boolean isSimulationSyncEnabled() {
+        return plugin.getConfig().getInt("sync-simulation-distance-percent", 100) > 0;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,8 +5,11 @@ colour: "§e§l(!) §e"
 error-colour: "§c§l(!) §c"
 success-colour: "§a§l(!) §a"
 
-# Whether setting view distance also sets simulation distance
-sync-simulation-distance: true
+# Percentage of view distance to use for simulation distance (0-100)
+# 100 = simulation distance equals view distance
+# 60 = simulation distance is 60% of view distance
+# Set to 0 to disable syncing (simulation distance will use its own settings)
+sync-simulation-distance-percent: 60
 
 # Default view distance for anyone who joins the server (Must be between 2 and 32)
 default-distance: 32
@@ -17,6 +20,16 @@ max-distance: 32
 
 # Minimum view distance for anyone (Cannot be less than 2)
 min-distance: 2
+
+# Default simulation distance for anyone who joins the server (Must be between 2 and 32)
+default-simulation-distance: 10
+bedrock-default-simulation-distance: 10
+
+# Maximum simulation distance for anyone (Cannot exceed 32)
+max-simulation-distance: 32
+
+# Minimum simulation distance for anyone (Cannot be less than 2)
+min-simulation-distance: 2
 
 # Whether to save player view distance preferences to disk (defaults to true)
 # When disabled, players start fresh each session with default/LuckPerms settings


### PR DESCRIPTION
Implement simulation distance syncing based on view distance configuration.

This is an initial implementation that syncs simulation distance with the 
player's view distance setting. Further improvements may be needed.

Closes #27